### PR TITLE
Use Steam instead of SteamSpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,9 @@
 ## Use
 
 * Install required modules, e.g. `pip3 install -r requirements.txt`.
-* Run `./dump-games.py`. This will take a while as we respect SteamSpy’s 1/min [ratelimit](https://steamspy.com/api.php) on `all` requests.
+* Run `./dump-steam-games.py`. This will take a few days due to rate-limiting on the API to fetch game details and cache them in SQLite.
     * This only needs to be run the first time and any time you need to update the locally cached list of games.
-* List the publishers and developers you want to ignore in `games_to_ignore.yaml`.
-* Run `./ignore-games.py`.
+* List the publishers and developers you want to ignore in `steam-games-to-ignore.yaml`.
+* Run `./ignore-steam-games.py`.
 * Login to Steam on the browser window that opens under Selenium’s control.
 * Enjoy the automation.
-
-## Thanks
-
-Thanks to [SteamSpy](https://steamspy.com) for making the list of games on Steam available.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@
 ## Thanks
 
 Thanks to [SteamSpy](https://steamspy.com) for making the list of games on Steam available.
+
+
+
+select appid, json_extract(details, '$.data.name') from steam_app_details, json_each(details, '$.data.publishers') where json_each.value = 'Valve';
+select appid, json_extract(details, '$.data.name') from steam_app_details where details -> '$.data.support_info.url' like '%http://steamcommunity.com/app/%';

--- a/README.md
+++ b/README.md
@@ -13,8 +13,3 @@
 ## Thanks
 
 Thanks to [SteamSpy](https://steamspy.com) for making the list of games on Steam available.
-
-
-
-select appid, json_extract(details, '$.data.name') from steam_app_details, json_each(details, '$.data.publishers') where json_each.value = 'Valve';
-select appid, json_extract(details, '$.data.name') from steam_app_details where details -> '$.data.support_info.url' like '%http://steamcommunity.com/app/%';

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,1 @@
+from .db import Database

--- a/db/db.py
+++ b/db/db.py
@@ -28,12 +28,24 @@ class Database():
                 '''
         cursor.execute(query, (appid, name))
 
+    def get_app_count(self) -> int:
+        entries = []
+        with self.connection:
+            cursor = self.connection.cursor()
+            query = '''
+                  select count(*) count
+                  from steam_apps
+                  '''
+            cursor.execute(query)
+
+            return next(cursor)["count"]
+
     def list_apps_missing_details(self):
         entries = []
         with self.connection:
             cursor = self.connection.cursor()
             query = '''
-                  select sa.appid appid
+                  select sa.appid appid, sa.name name
                   from steam_apps sa left join steam_app_details sad on (sa.appid = sad.appid)
                   where sad.appid is null
                   '''

--- a/db/db.py
+++ b/db/db.py
@@ -1,0 +1,101 @@
+import sqlite3
+import os
+import time
+from datetime import datetime, timezone
+
+from dataclasses import dataclass
+
+from .ddl import MaintainSchema
+
+
+@dataclass
+class Database():
+
+    def __post_init__(self):
+        self.db_path = "data/steam.db"
+
+        self.connection = sqlite3.connect(self.db_path)
+        self.connection.row_factory = sqlite3.Row
+
+        MaintainSchema(self.connection)
+
+    def add_app(self, appid: int, name: str):
+        # Used inside a transaction, so no `with`
+        cursor = self.connection.cursor()
+        query = '''
+                insert or ignore into steam_apps(appid, name)
+                values(?,?)
+                '''
+        cursor.execute(query, (appid, name))
+
+    def list_apps_missing_details(self):
+        entries = []
+        with self.connection:
+            cursor = self.connection.cursor()
+            query = '''
+                  select sa.appid appid
+                  from steam_apps sa left join steam_app_details sad on (sa.appid = sad.appid)
+                  where sad.appid is null
+                  '''
+            cursor.execute(query)
+
+            for row in cursor:
+                entry = {}
+                for col in row.keys():
+                    entry[col] = row[col]
+                entries.append(entry)
+
+        return entries
+
+    def upsert_app_details(self, appid: int, details: any):
+        with self.connection:
+            cursor = self.connection.cursor()
+            query = '''
+                  insert into steam_app_details(appid, details)
+                  values(?,jsonb(?))
+                  on conflict(appid) do
+                  update set
+                    details = jsonb(?)
+                  '''
+            cursor.execute(query, (appid, details, details))
+
+    def list_apps_array_filter(self, key: str, value: str):
+        entries = []
+        key_param = f"$.data.{key}"
+        with self.connection:
+            cursor = self.connection.cursor()
+            query = '''
+                  select appid, json_extract(details, '$.data.name') name
+                  from steam_app_details, json_each(details, ?)
+                  where json_each.value = ?
+                  '''
+            cursor.execute(query, (key_param, value))
+
+            for row in cursor:
+                entry = {}
+                for col in row.keys():
+                    entry[col] = row[col]
+                entries.append(entry)
+
+        return entries
+
+    def list_apps_value_filter(self, key: str, value: str):
+        # self.connection.set_trace_callback(print)
+        entries = []
+        key_param = f"$.data.{key}"
+        with self.connection:
+            cursor = self.connection.cursor()
+            query = '''
+                  select appid, json_extract(details, '$.data.name') name
+                  from steam_app_details
+                  where json_extract(details, ?) = ?
+                  '''
+            cursor.execute(query, (key_param, value))
+
+            for row in cursor:
+                entry = {}
+                for col in row.keys():
+                    entry[col] = row[col]
+                entries.append(entry)
+
+        return entries

--- a/db/db.py
+++ b/db/db.py
@@ -77,8 +77,9 @@ class Database():
         with self.connection:
             cursor = self.connection.cursor()
             query = '''
-                  select appid, json_extract(details, '$.data.name') name
-                  from steam_app_details, json_each(details, ?)
+                  select sad.appid appid, json_extract(sad.details, '$.data.name') name, sai.ignored ignored
+                  from steam_app_details as sad
+                    left join steam_apps_ignored as sai using (appid), json_each(sad.details, ?)
                   where json_each.value = ?
                   '''
             cursor.execute(query, (key_param, value))
@@ -97,8 +98,9 @@ class Database():
         with self.connection:
             cursor = self.connection.cursor()
             query = '''
-                  select appid, json_extract(details, '$.data.name') name
-                  from steam_app_details
+                  select sad.appid appid, json_extract(sad.details, '$.data.name') name, sai.ignored ignored
+                  from steam_app_details as sad
+                    left join steam_apps_ignored as sai using (appid)
                   where json_extract(details, ?) = ?
                   '''
             cursor.execute(query, (key_param, value))

--- a/db/db.py
+++ b/db/db.py
@@ -92,7 +92,6 @@ class Database():
         return entries
 
     def list_apps_value_filter(self, key: str, value: str):
-        # self.connection.set_trace_callback(print)
         entries = []
         key_param = f"$.data.{key}"
         with self.connection:
@@ -111,3 +110,15 @@ class Database():
                 entries.append(entry)
 
         return entries
+
+    def upsert_game_ignored(self, appid: int):
+        with self.connection:
+            cursor = self.connection.cursor()
+            query = '''
+                  insert into steam_apps_ignored(appid, ignored)
+                  values(?, 'Y')
+                  on conflict(appid) do
+                  update set
+                    ignored = 'Y'
+                  '''
+            cursor.execute(query, (appid,))

--- a/db/ddl.py
+++ b/db/ddl.py
@@ -1,0 +1,61 @@
+import sqlite3
+import os
+
+from dataclasses import dataclass
+
+import db.schema_upgrades
+
+
+@dataclass()
+class MaintainSchema():
+    connection: sqlite3.Connection
+    target_schema_version: int = 0
+
+    def __post_init__(self):
+        self.get_schema_version()
+        self.upgrade_schema()
+
+    def upgrade_schema(self):
+        assert self.schema_version <= self.target_schema_version
+        if self.schema_version == self.target_schema_version:
+            return
+
+        print(
+            f"Processing schema upgrades from v{self.schema_version} to v{self.target_schema_version}")
+        for v in range(self.schema_version+1, self.target_schema_version+1):
+            print(f"Upgrading schema to v{v}")
+            class_ = getattr(db.schema_upgrades, f"SchemaUpgradeV{v}")
+            class_(self.connection)
+        self.get_schema_version()
+        assert self.schema_version == self.target_schema_version
+
+    def get_schema_version(self) -> int:
+        self.ddl_create_table_steam_metadata()
+
+        schema_version_str = ""
+        with self.connection:
+            cursor = self.connection.cursor()
+            query = '''
+                  select value
+                  from steam_metadata
+                  where key = 'schema_version'
+                  '''
+            cursor.execute(query)
+
+            for row in cursor:
+                schema_version_str = row["value"]
+
+            if schema_version_str == "":
+                schema_version_str = "-1"
+                self.connection.execute('''insert into steam_metadata(key, value)
+                                        values('schema_version', '-1')
+                                    ''')
+
+        self.schema_version = int(schema_version_str)
+
+    def ddl_create_table_steam_metadata(self):
+        self.connection.execute('''create table if not exists steam_metadata (
+                                 key text not null primary key,
+                                 value text not null
+                                 )
+                              ''')

--- a/db/schema_upgrades/__init__.py
+++ b/db/schema_upgrades/__init__.py
@@ -1,0 +1,1 @@
+from .v0 import SchemaUpgradeV0

--- a/db/schema_upgrades/schema_upgrade.py
+++ b/db/schema_upgrades/schema_upgrade.py
@@ -1,0 +1,19 @@
+import sqlite3
+
+from dataclasses import dataclass
+
+
+@dataclass()
+class SchemaUpgrade():
+    connection: sqlite3.Connection
+    schema_version: int
+
+    def set_version(self):
+        with self.connection:
+            cursor = self.connection.cursor()
+            query = '''
+                  update steam_metadata
+                  set value = ?
+                  where key = 'schema_version'
+                  '''
+            cursor.execute(query, (str(self.schema_version),))

--- a/db/schema_upgrades/v0.py
+++ b/db/schema_upgrades/v0.py
@@ -17,6 +17,7 @@ class SchemaUpgradeV0(SchemaUpgrade):
     def upgrade(self):
         self.ddl_create_table_steam_apps()
         self.ddl_create_table_steam_app_details()
+        self.ddl_create_table_steam_app_ignored()
 
     def ddl_create_table_steam_apps(self):
         self.connection.execute('''create table if not exists steam_apps (
@@ -40,7 +41,7 @@ class SchemaUpgradeV0(SchemaUpgrade):
     def ddl_create_table_steam_app_ignored(self):
         self.connection.execute('''create table if not exists steam_apps_ignored (
                                 appid integer not null,
-                                ignored not null char(1),
+                                ignored char(1) not null,
                                 foreign key (appid) references steam_apps (appid)
                                 )
         ''')

--- a/db/schema_upgrades/v0.py
+++ b/db/schema_upgrades/v0.py
@@ -36,3 +36,20 @@ class SchemaUpgradeV0(SchemaUpgrade):
                                  details blob not null
                                  )
                               ''')
+
+    def ddl_create_table_steam_app_ignored(self):
+        self.connection.execute('''create table if not exists steam_apps_ignored (
+                                appid integer not null,
+                                ignored not null char(1),
+                                foreign key (appid) references steam_apps (appid)
+                                )
+        ''')
+        self.connection.execute('''create unique index if not exists steam_apps_ignored_1 on steam_apps_ignored (
+                                 appid
+                                 )
+                              ''')
+        self.connection.execute('''create index if not exists steam_apps_ignored_2 on steam_apps_ignored (
+                                 ignored,
+                                 appid
+                                 )
+                              ''')

--- a/db/schema_upgrades/v0.py
+++ b/db/schema_upgrades/v0.py
@@ -1,0 +1,38 @@
+import sqlite3
+
+from dataclasses import dataclass
+
+from .schema_upgrade import SchemaUpgrade
+
+
+@dataclass()
+class SchemaUpgradeV0(SchemaUpgrade):
+    connection: sqlite3.Connection
+    schema_version: int = 0
+
+    def __post_init__(self):
+        self.upgrade()
+        self.set_version()
+
+    def upgrade(self):
+        self.ddl_create_table_steam_apps()
+        self.ddl_create_table_steam_app_details()
+
+    def ddl_create_table_steam_apps(self):
+        self.connection.execute('''create table if not exists steam_apps (
+                                 appid integer primary key,
+                                 name text not null
+                                 )
+                              ''')
+        self.connection.execute('''create index if not exists steam_apps_1 on steam_apps (
+                                 name,
+                                 appid
+                                 )
+                              ''')
+
+    def ddl_create_table_steam_app_details(self):
+        self.connection.execute('''create table if not exists steam_app_details (
+                                 appid integer primary key,
+                                 details blob not null
+                                 )
+                              ''')

--- a/dump-steam-games.py
+++ b/dump-steam-games.py
@@ -8,6 +8,7 @@ import sys
 from threading import Event
 import time
 
+# TODO just import console
 import rich
 from rich.progress import (
     BarColumn,
@@ -23,10 +24,10 @@ from db import Database
 
 
 class SteamDumper():
-    def __init__(self, debug, done_event):
+    def __init__(self, done_event: Event, debug: bool):
         self.db = Database()
-        self.debug = debug
         self.done_event = done_event
+        self.debug = debug
 
         width = rich.console.Console().width
         self.max_name_width = int(width / 4)
@@ -56,6 +57,7 @@ class SteamDumper():
         if self.debug:
             print(*args, **kwargs)
 
+    # TODO: refactor
     def ellipsise(self, name: str) -> str:
         if len(name) <= self.max_name_width:
             return name
@@ -178,5 +180,5 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    steam_dumper = SteamDumper(args.debug, done_event)
+    steam_dumper = SteamDumper(done_event, debug)
     steam_dumper.run(args.refresh_list, args.fetch_missing_details)

--- a/dump-steam-games.py
+++ b/dump-steam-games.py
@@ -3,15 +3,47 @@
 import argparse
 import json
 import requests
+import signal
 import sys
+from threading import Event
 import time
+
+import rich
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TextColumn,
+    TimeRemainingColumn,
+)
 
 from db import Database
 
 
 class SteamDumper():
-    def __init__(self):
+    def __init__(self, debug, done_event):
         self.db = Database()
+        self.debug = debug
+        self.done_event = done_event
+
+        width = rich.console.Console().width
+        self.max_name_width = int(width / 4)
+
+        self.progress = Progress(
+            SpinnerColumn(spinner_name='moon'),
+            TextColumn(
+                "[bold blue]{task.fields[name]:" + str(self.max_name_width) + "}", justify="right"),
+            BarColumn(bar_width=None),
+            "[progress.percentage]{task.percentage:>3.1f}%",
+            "•",
+            MofNCompleteColumn(),
+            "•",
+            TextColumn('[yellow]{task.fields[sleep]:2.2f}"'),
+            "•",
+            TimeRemainingColumn(elapsed_when_finished=True),
+        )
 
     def run(self, refresh_list: bool, fetch_missing_details: bool):
         if refresh_list:
@@ -19,6 +51,22 @@ class SteamDumper():
 
         if fetch_missing_details:
             self.fetch_missing_details()
+
+    def debug_print(self, *args, **kwargs):
+        if self.debug:
+            print(*args, **kwargs)
+
+    def ellipsise(self, name: str) -> str:
+        if len(name) <= self.max_name_width:
+            return name
+
+        half = int(self.max_name_width / 2)
+        remainder = self.max_name_width % 2
+
+        left = name[:half-(1-remainder)]
+        right = name[-half:]
+
+        return left + "…" + right
 
     def refresh_list(self):
         url = 'http://api.steampowered.com/ISteamApps/GetAppList/v0002/?format=json'
@@ -33,8 +81,7 @@ class SteamDumper():
         self.db.connection.commit()
 
     def fetch_missing_details(self):
-        # 1" is too short, but 2" works fine
-        sleep_time = 1.1
+        sleep_time = 1.2
         penalty = 0.1
         grace = 0.01
         rate_limit_upper_bound_sleep_time = 0
@@ -43,54 +90,72 @@ class SteamDumper():
         app_count = self.db.get_app_count()
         missing_count = len(appids)
         missing_pct = missing_count * 100 / app_count
-        print(f"Total missing {missing_count}, {missing_pct:.2f}%")
+        self.debug_print(f"Total missing {missing_count}, {missing_pct:.2f}%")
         fetched = 0
-        for appid_row in appids:
-            appid = appid_row['appid']
-            name = appid_row['name']
-            print(f"Fetching details for {name} / {appid}")
-            url = f"https://store.steampowered.com/api/appdetails?appids={
-                appid}"
-            retry = True
-            while retry:
-                retry = False
-                response = requests.get(url)
-                if response.status_code != 200:
-                    print(f"Unexpected server response code {
-                          response.status_code}: {response.headers}")
-                    if response.status_code == 429:
-                        # Rate limited
-                        rate_limit_upper_bound_sleep_time = sleep_time
-                        sleep_time += penalty
-                        print(f"Rate limit penalty applied. Sleep time: {
-                              sleep_time}")
-                        time.sleep(120)
-                        retry = True
-                    else:
-                        # Pause and skip, we’ll retry next run anyway
-                        time.sleep(30)
-                        break
-            else:
-                appdetails = response.json()
-                for appid in appdetails:
-                    self.db.upsert_app_details(
-                        appid, json.dumps(appdetails[appid]))
 
-                fetched += 1
-                if fetched % 100 == 0:
-                    sleep_time_tmp = sleep_time - grace
-                    if sleep_time_tmp > rate_limit_upper_bound_sleep_time:
-                        sleep_time = sleep_time_tmp
+        with self.progress:
+            task = self.progress.add_task(
+                description="", total=app_count, completed=app_count-missing_count, name="Fetch missing details", sleep=sleep_time)
+            for appid_row in appids:
+                if self.done_event.is_set():
+                    return
 
-                    missing_tmp = missing_count - fetched
-                    missing_tmp_pct = missing_tmp * 100 / app_count
-                    print(f'Total missing {missing_tmp} / {
-                          missing_tmp_pct:.2f}%. Sleep time: {sleep_time}')
+                appid = appid_row['appid']
+                name = appid_row['name']
+                self.progress.update(
+                    task, completed=app_count-missing_count+fetched, name=self.ellipsise(name), sleep=sleep_time)
+                self.debug_print(f"Fetching details for {name} / {appid}")
+                url = f"https://store.steampowered.com/api/appdetails?appids={
+                    appid}"
+                retry = True
+                while retry:
+                    retry = False
+                    response = requests.get(url)
+                    if response.status_code != 200:
+                        self.debug_print(f"Unexpected server response code {
+                            response.status_code}: {response.headers}")
+                        if response.status_code == 429:
+                            # Rate limited
+                            rate_limit_upper_bound_sleep_time = sleep_time
+                            sleep_time += penalty
+                            self.debug_print(f"Rate limit penalty applied. Sleep time: {
+                                sleep_time}")
+                            time.sleep(120)
+                            retry = True
+                        else:
+                            # Pause and skip, we’ll retry next run anyway
+                            time.sleep(30)
+                            break
+                else:
+                    appdetails = response.json()
+                    for appid in appdetails:
+                        self.db.upsert_app_details(
+                            appid, json.dumps(appdetails[appid]))
 
-                time.sleep(sleep_time)
+                    fetched += 1
+                    self.progress.update(
+                        task, completed=app_count-missing_count+fetched, name=self.ellipsise(name), sleep=sleep_time)
+                    if fetched % 100 == 0:
+                        sleep_time_tmp = sleep_time - grace
+                        if sleep_time_tmp > rate_limit_upper_bound_sleep_time:
+                            sleep_time = sleep_time_tmp
+
+                        missing_tmp = missing_count - fetched
+                        missing_tmp_pct = missing_tmp * 100 / app_count
+                        self.debug_print(f'Total missing {missing_tmp} / {
+                            missing_tmp_pct:.2f}%. Sleep time: {sleep_time}')
+
+                    time.sleep(sleep_time)
+
+
+def handle_sigint(signum, frame):
+    done_event.set()
 
 
 if __name__ == '__main__':
+    done_event = Event()
+    signal.signal(signal.SIGINT, handle_sigint)
+
     parser = argparse.ArgumentParser(
         description='Dumps Steam games to a local database')
 
@@ -105,9 +170,13 @@ if __name__ == '__main__':
                         type=bool,
                         action=argparse.BooleanOptionalAction,
                         default=False)
+    parser.add_argument("--debug",
+                        help="Verbose/debug mode",
+                        type=bool,
+                        action=argparse.BooleanOptionalAction,
+                        default=False)
 
     args = parser.parse_args()
-    print(f"{args}")
 
-    steam_dumper = SteamDumper()
+    steam_dumper = SteamDumper(args.debug, done_event)
     steam_dumper.run(args.refresh_list, args.fetch_missing_details)

--- a/dump-steam-games.py
+++ b/dump-steam-games.py
@@ -8,8 +8,7 @@ import sys
 from threading import Event
 import time
 
-# TODO just import console
-import rich
+from rich.console import Console
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -29,7 +28,7 @@ class SteamDumper():
         self.done_event = done_event
         self.debug = debug
 
-        width = rich.console.Console().width
+        width = Console().width
         self.max_name_width = int(width / 4)
 
         self.progress = Progress(

--- a/dump-steam-games.py
+++ b/dump-steam-games.py
@@ -55,7 +55,7 @@ class SteamDumper():
             for appid in appdetails:
                 self.db.upsert_app_details(
                     appid, json.dumps(appdetails[appid]))
-            time.sleep(4)
+            time.sleep(2)
 
 
 if __name__ == '__main__':

--- a/dump-steam-games.py
+++ b/dump-steam-games.py
@@ -128,10 +128,14 @@ class SteamDumper():
                             time.sleep(30)
                             break
                 else:
-                    appdetails = response.json()
-                    for appid in appdetails:
-                        self.db.upsert_app_details(
-                            appid, json.dumps(appdetails[appid]))
+                    try:
+                        appdetails = response.json()
+                        for appid in appdetails:
+                            self.db.upsert_app_details(
+                                appid, json.dumps(appdetails[appid]))
+                    except requests.exceptions.JSONDecodeError as err:
+                        print(f"Unexpected {err=}, {type(err)=}")
+                        print(f"{response.content}")
 
                     fetched += 1
                     self.progress.update(
@@ -179,5 +183,5 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    steam_dumper = SteamDumper(done_event, debug)
+    steam_dumper = SteamDumper(done_event, args.debug)
     steam_dumper.run(args.refresh_list, args.fetch_missing_details)

--- a/dump-steam-games.py
+++ b/dump-steam-games.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import requests
+import sys
+import time
+
+from db import Database
+
+
+class SteamDumper():
+    def __init__(self):
+        self.db = Database()
+
+    def run(self, refresh_list: bool, fetch_missing_details: bool):
+        if refresh_list:
+            self.refresh_list()
+
+        if fetch_missing_details:
+            self.fetch_missing_details()
+
+    def refresh_list(self):
+        url = 'http://api.steampowered.com/ISteamApps/GetAppList/v0002/?format=json'
+        response = requests.get(url)
+        applist = response.json()
+
+        self.db.connection.execute("BEGIN")
+        for app in applist['applist']['apps']:
+            appid = app['appid']
+            name = app['name']
+            self.db.add_app(appid, name)
+        self.db.connection.commit()
+
+    def fetch_missing_details(self):
+        appids = self.db.list_apps_missing_details()
+        print(f"total missing {len(appids)}")
+        for appid_row in appids:
+            appid = appid_row['appid']
+            print(f"missing {appid}")
+            url = f"https://store.steampowered.com/api/appdetails?appids={
+                appid}"
+            retry = True
+            while retry:
+                retry = False
+                response = requests.get(url)
+                if response.status_code != 200:
+                    print(f"{response.status_code}: {response.headers}")
+                    if response.status_code == 429:
+                        time.sleep(300)
+                        retry = True
+                    else:
+                        sys.exit(1)
+            appdetails = response.json()
+            for appid in appdetails:
+                self.db.upsert_app_details(
+                    appid, json.dumps(appdetails[appid]))
+            time.sleep(4)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Dumps Steam games to a local database')
+
+    parser.add_argument("--refresh-list",
+                        help="Whether to fetch the full list of games from Steam",
+                        type=bool,
+                        action=argparse.BooleanOptionalAction,
+                        default=False)
+
+    parser.add_argument("--fetch-missing-details",
+                        help="Whether to fetch details for apps that are missing them",
+                        type=bool,
+                        action=argparse.BooleanOptionalAction,
+                        default=False)
+
+    args = parser.parse_args()
+    print(f"{args}")
+
+    steam_dumper = SteamDumper()
+    steam_dumper.run(args.refresh_list, args.fetch_missing_details)

--- a/dump-steamspy-games.py
+++ b/dump-steamspy-games.py
@@ -20,7 +20,7 @@ def get_games():
         response = requests.get(url)
         games = response.json()
 
-        filename = f'data/page_{page}.json'
+        filename = f'data/steamspy/page_{page}.json'
         with open(filename, 'w') as file:
             file.write(response.text)
 

--- a/games_to_ignore.yaml
+++ b/games_to_ignore.yaml
@@ -1,4 +1,0 @@
-developer:
-- Beam Bong Games
-publisher:
-- Hede

--- a/ignore-steam-games.py
+++ b/ignore-steam-games.py
@@ -156,6 +156,8 @@ class SteamIgnoreGames():
 
                     if not dry_run and ignored != 'Y':
                         self.ignore_game(driver, appid, name)
+                    elif ignored == 'Y':
+                        self.logger.debug(f"{name} already ignored")
 
                     self.progress.update(task, advance=1)
 

--- a/ignore-steam-games.py
+++ b/ignore-steam-games.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import os.path
+import requests
+import time
+import yaml
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+from db import Database
+
+
+class SteamIgnoreGames():
+    def __init__(self):
+        self.db = Database()
+
+    def login_to_steam(self, driver):
+        driver.get('https://store.steampowered.com/login/')
+
+        wait = WebDriverWait(driver, 60)
+        wait.until(EC.title_is("Welcome to Steam"))
+
+        print("Logged in")
+
+    def ignore_game(self, driver, appid):
+        game_url = f'https://store.steampowered.com/app/{appid}/'
+        driver.get(game_url)
+        print("Loading game page")
+
+        wait = WebDriverWait(driver, 10)
+        ignoreBtn = wait.until(
+            EC.element_to_be_clickable((By.ID, "ignoreBtn")))
+
+        ignore = driver.find_element(
+            By.XPATH, '//div[@id="ignoreBtn"]//span[contains(text(),"Ignore")][1]')
+        ignored = driver.find_element(
+            By.XPATH, '//div[@id="ignoreBtn"]//span[contains(text(),"Ignored")]')
+
+        print(ignore, ignore.is_displayed())
+        print(ignored, ignored.is_displayed())
+
+        if ignored.is_displayed():
+            print("Game is already ignored, skipping")
+        else:
+            ignoreBtn.click()
+            time.sleep(1)
+            print("Ignoring game", ignored.is_displayed())
+
+    def get_games_from_publisher(self, type, properties):
+        games = []
+        for value in properties['values']:
+            if properties['kind'] == 'list':
+                games.extend(self.db.list_apps_array_filter(type, value))
+            elif properties['kind'] == 'value':
+                games.extend(self.db.list_apps_value_filter(type, value))
+            else:
+                print(f"Unknown filter kind: {properties}")
+
+        return games
+
+    def run(self):
+        # Initialize the browser
+        # driver = webdriver.Chrome()
+
+        # Log in to Steam
+        # self.login_to_steam(driver)
+
+        with open("steam-games-to-ignore.yaml", "r") as f:
+            games_to_ignore = yaml.safe_load(f)
+
+            games = []
+            for type in games_to_ignore:
+                print(type, games_to_ignore[type])
+                try:
+                    properties = games_to_ignore[type]
+                except KeyError:
+                    continue
+
+                g = self.get_games_from_publisher(type, properties)
+                print(g)
+                print(f"Found {len(g)} games by {type} {properties}")
+                games.extend(g)
+
+            # for appid, name in games:
+            #     self.ignore_game(driver, appid)
+            #     print(f'Ignored {name} (appid: {appid})')
+
+        # driver.quit()
+
+
+if __name__ == '__main__':
+    sig = SteamIgnoreGames()
+    sig.run()

--- a/ignore-steam-games.py
+++ b/ignore-steam-games.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import json
 import os
 import os.path
@@ -29,7 +30,7 @@ class SteamIgnoreGames():
 
         print("Logged in")
 
-    def ignore_game(self, driver, appid):
+    def ignore_game(self, driver, appid, name):
         game_url = f'https://store.steampowered.com/app/{appid}/'
         driver.get(game_url)
         print("Loading game page")
@@ -46,12 +47,15 @@ class SteamIgnoreGames():
         print(ignore, ignore.is_displayed())
         print(ignored, ignored.is_displayed())
 
+        # TODO: rewrite this logic and add retries or wait until ignored is displayed iso using a sleep
         if ignored.is_displayed():
-            print("Game is already ignored, skipping")
+            print(f"{name} is already ignored, skipping")
         else:
             ignoreBtn.click()
             time.sleep(1)
-            print("Ignoring game", ignored.is_displayed())
+            print(f"Ignored {name}: {ignored.is_displayed()}")
+            if ignored.is_displayed():
+                self.db.upsert_game_ignored(appid)
 
     def get_games_from_publisher(self, type, properties):
         games = []
@@ -89,7 +93,7 @@ class SteamIgnoreGames():
                 games.extend(g)
 
             # for appid, name in games:
-            #     self.ignore_game(driver, appid)
+            #     self.ignore_game(driver, appid, name)
             #     print(f'Ignored {name} (appid: {appid})')
 
         # driver.quit()

--- a/ignore-steamspy-games.py
+++ b/ignore-steamspy-games.py
@@ -28,8 +28,6 @@ def ignore_game(driver, appid):
     driver.get(game_url)
     print("Loading game page")
 
-    # time.sleep(3)
-
     wait = WebDriverWait(driver, 10)
     ignoreBtn = wait.until(EC.element_to_be_clickable((By.ID, "ignoreBtn")))
 
@@ -51,7 +49,7 @@ def ignore_game(driver, appid):
 
 def get_games_from_publisher(field, name):
     games = []
-    path = "./data"
+    path = "./data/steamspy"
     for filename in next(os.walk(path), (None, None, []))[2]:
         with open(os.path.join(path, filename), 'r') as file:
             all_games = json.load(file)
@@ -70,7 +68,7 @@ driver = webdriver.Chrome()
 # Log in to Steam
 login_to_steam(driver)
 
-with open("games_to_ignore.yaml", "r") as f:
+with open("steamspy-games-to-ignore.yaml", "r") as f:
     games_to_ignore = yaml.safe_load(f)
 
     games = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 selenium
 requests
 pyyaml
+rich

--- a/steam-games-to-ignore.yaml
+++ b/steam-games-to-ignore.yaml
@@ -1,17 +1,19 @@
 developers:
   kind: list
   values:
-  - Beam Bong Games
-  - Save Giant Girl
   - Aztech
+  - Beam Bong Games
+  - edybtt Studios
+  - Save Giant Girl
 
 publishers:
   kind: list
   values:
-  #- Hede
-  - Save Giant Girl
   - Aztech
   - Azerbaijan Technology
+  - edybtt Studios
+  - Hede
+  - Save Giant Girl
 
 support_info.url:
   kind: value

--- a/steam-games-to-ignore.yaml
+++ b/steam-games-to-ignore.yaml
@@ -3,16 +3,22 @@ developers:
   values:
   - Beam Bong Games
   - Save Giant Girl
+  - Aztech
+
 publishers:
   kind: list
   values:
-  - Hede
+  #- Hede
   - Save Giant Girl
+  - Aztech
+  - Azerbaijan Technology
   # - Valve
+
 support_info.url:
   kind: value
   values:
   - http://hede.ru
+
 support_info.email:
   kind: value
   values:

--- a/steam-games-to-ignore.yaml
+++ b/steam-games-to-ignore.yaml
@@ -1,0 +1,20 @@
+developers:
+  kind: list
+  values:
+  - Beam Bong Games
+  - Save Giant Girl
+publishers:
+  kind: list
+  values:
+  - Hede
+  - Save Giant Girl
+  # - Valve
+support_info.url:
+  kind: value
+  values:
+  - http://hede.ru
+support_info.email:
+  kind: value
+  values:
+  - info@hede.ru
+  # - support@quanticlab.com

--- a/steam-games-to-ignore.yaml
+++ b/steam-games-to-ignore.yaml
@@ -12,7 +12,6 @@ publishers:
   - Save Giant Girl
   - Aztech
   - Azerbaijan Technology
-  # - Valve
 
 support_info.url:
   kind: value
@@ -23,4 +22,3 @@ support_info.email:
   kind: value
   values:
   - info@hede.ru
-  # - support@quanticlab.com

--- a/steamspy-games-to-ignore.yaml
+++ b/steamspy-games-to-ignore.yaml
@@ -1,0 +1,6 @@
+developer:
+#- Beam Bong Games
+- Save Giant Girl
+publisher:
+#- Hede
+- Save Giant Girl

--- a/steamspy-games-to-ignore.yaml
+++ b/steamspy-games-to-ignore.yaml
@@ -1,6 +1,9 @@
 developer:
-#- Beam Bong Games
+- Beam Bong Games
 - Save Giant Girl
+- Aztech
 publisher:
 #- Hede
 - Save Giant Girl
+- Aztech
+- Azerbaijan Technology


### PR DESCRIPTION
SteamSpy does sampling to gather its data, so it doesn’t actually have a complete game list. Switch to using Steam’s APIs instead.